### PR TITLE
Remove option to provide the client id

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Gets the m3u8 direct stream URLs of a live stream on twitch.tv.
 `npm install --save twitch-get-stream`
 
 ```javascript
-var twitchStreams = require('twitch-get-stream')('<your-client-id>'); // twitch now ENFORCES client id usage, so this is required.
+var twitchStreams = require('twitch-get-stream')
 ...
 twitchStreams.get('channel')
     .then(function(streams) {

--- a/examples/getChannelStreams.js
+++ b/examples/getChannelStreams.js
@@ -1,5 +1,4 @@
-var clid = require('./clid.json').clid; // place in clid.json as a property 'clid' - can be obtained from your twitch.tv settings -> connections -> register developer app
-var twitchStreams = require('../')(clid);
+var twitchStreams = require('../');
 
 twitchStreams.get('Monstercat')
     .then(function(streams) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var axios = require('axios');
 var M3U = require('playlist-parser').M3U;
 var qs = require('querystring');
 
-var clientId;
+const clientId = 'kimne78kx3ncx6brgo4mv6wki5h1ko';
 
 // Thanks michaelowens, :)
 // Simple titlecase thing, capitalize first letter
@@ -103,12 +103,8 @@ var getStreamUrls = function(channel) { // This returns the one with a custom fu
         });
 }
 
-module.exports = 
-    function(clid) {
-        clientId = clid;
-        return {
-            get: getStreamUrls,
-            raw: getPlaylistOnly,
-            rawParsed: getPlaylistParsed          
-        };
-    };
+module.exports = {
+    get: getStreamUrls,
+    raw: getPlaylistOnly,
+    rawParsed: getPlaylistParsed  
+}


### PR DESCRIPTION
There is no point in using client ids that are created by us, since they will not work ([see this](https://discuss.dev.twitch.tv/t/410-gone-when-requesting-private-api-api-namespace-with-3rd-party-client-id/23060/12))

The client id provided is the one that's used in youtube-dl and streamlink, I guess they got it from the official site, and for now, it works perfectly.
